### PR TITLE
feat(d_h): upgrading rust and rusoto

### DIFF
--- a/definitely_hyped/Cargo.toml
+++ b/definitely_hyped/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = ["Andrew Crites <acjrites@gmail.com>"]
 
 [dependencies]
-json = "0.11.9"
-rusoto_core = "0.28.0"
-rusoto_s3 = "0.28.0"
+json = "0.11.13"
+rusoto_core = "0.36.0"
+rusoto_s3 = "0.36.0"
+futures = "0.1.25"
+reqwest = "0.9.5"

--- a/definitely_hyped/src/main.rs
+++ b/definitely_hyped/src/main.rs
@@ -7,9 +7,8 @@ use std::fs::read_dir;
 use std::path::Path;
 use std::env;
 
-use rusoto_core::{ChainProvider, ProfileProvider, Region};
+use rusoto_core::Region;
 use rusoto_s3::{S3, S3Client, PutObjectRequest};
-use rusoto_core::default_tls_client;
 
 fn main() {
     const REPO_PATH: &'static str = "DefinitelyTyped";
@@ -36,19 +35,6 @@ fn main() {
         .map(|path| path.to_str().unwrap().replace(&format!("{}/types/", REPO_PATH), ""))
         .collect();
 
-    let profile = match env::var("AWS_PROFILE") {
-        Ok(val) => val.to_string(),
-        Err(_) => "default".to_string(),
-    };
-
-    let region = match env::var("AWS_REGION") {
-        Ok(val) => val.to_string(),
-        Err(_) => {
-            println!("{}", "You must provide an AWS Region");
-            exit(1);
-        }
-    };
-
     let bucket = match env::var("BUCKET") {
         Ok(val) => val.to_string(),
         Err(_) => {
@@ -57,38 +43,12 @@ fn main() {
         }
     };
 
-    let mut profile_provider = ProfileProvider::new().unwrap();
-    profile_provider.set_profile(profile);
-    let chain_provider = ChainProvider::with_profile_provider(profile_provider);
-
-    let s3_client = S3Client::new(default_tls_client().unwrap(), chain_provider, region.parse::<Region>().unwrap());
-    s3_client.put_object(&PutObjectRequest {
+    let s3_client = S3Client::new(Region::UsEast1);
+    s3_client.put_object(PutObjectRequest {
         bucket: bucket,
         key: "@types.json".to_string(),
-        body: Some(json::stringify(types_names).into_bytes()),
+        body: Some(json::stringify(types_names).into_bytes().into()),
         acl: Some("public-read".to_string()),
-
-        request_payer: None,
-        content_encoding: None,
-        storage_class: None,
-        grant_read_acp: None,
-        server_side_encryption: None,
-        ssekms_key_id: None,
-        content_disposition: None,
-        metadata: None,
-        sse_customer_key: None,
-        website_redirect_location: None,
-        expires: None,
-        cache_control: None,
-        content_length: None,
-        grant_read: None,
-        grant_write_acp: None,
-        grant_full_control: None,
-        sse_customer_algorithm: None,
-        content_type: None,
-        content_language: None,
-        content_md5: None,
-        sse_customer_key_md5: None,
-        tagging: None,
-    }).expect("could not upload");
+        ..Default::default()
+    }).sync().expect("could not upload");
 }


### PR DESCRIPTION
Upgrading to the new version of `rusoto` which supports AWS environment variable settings out of the box (apparently).

See: https://stackoverflow.com/questions/53799059/uploading-a-string-to-s3-using-rusoto